### PR TITLE
Add second test for `_get_form` 

### DIFF
--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -34,6 +34,19 @@ class FormTest(unittest.TestCase):
         formxpath = '//form/..'
         self.assertRaises(ValueError, _get_form, response, formname, formid, formnumber, formxpath)
 
+    def test_get_form_None(self):
+        # GROUP 12 ADDED TEST CASE
+        response = _buildresponse(
+            b"""<form action="post.php" method="POST">
+            <input type="hidden" name="test" value="val1">
+            </form>""",
+            url="http://www.example.com/index.html")
+        formname = None
+        formid = None
+        formnumber = None
+        formxpath = None
+        self.assertIsNone(_get_form(response, formname, formid, formnumber, formxpath))
+
 
 class RequestTest(unittest.TestCase):
 

--- a/tests/test_http_request.py
+++ b/tests/test_http_request.py
@@ -20,7 +20,7 @@ class DatatypeTest(unittest.TestCase):
 
 
 class FormTest(unittest.TestCase):
-    
+
     def test_get_form(self):
         # GROUP 12 ADDED TEST CASE
         response = _buildresponse(
@@ -1305,7 +1305,7 @@ class JsonRequestTest(RequestTest):
         }
         r1 = self.request_class(url="http://www.example.com/", data=data)
         with warnings.catch_warnings(record=True) as _warnings:
-            r2 = r1.replace(method="POST", body=b"New body", data=data)
+            r1.replace(method="POST", body=b"New body", data=data)
             self.assertEqual(len(_warnings), 1)
 
     def setUp(self):


### PR DESCRIPTION
Add test for when the response body has a form element, but the other parameters are None in function `_get_form` in `scrapy\http\request\form.py`. This covers the branch 110&rightarrow;exit and induces 100% branch coverage of the function.

close #16 