### PR TITLE
test: add test for _get_method

### DIFF
--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -2,7 +2,7 @@ import unittest
 
 from scrapy.http import Request, FormRequest
 from scrapy.spiders import Spider
-from scrapy.utils.reqser import request_to_dict, request_from_dict, _get_method
+from scrapy.utils.reqser import request_to_dict, request_from_dict, _get_method # GROUP 12 ADDED IMPORT
 
 
 class RequestSerializationTest(unittest.TestCase):

--- a/tests/test_utils_reqser.py
+++ b/tests/test_utils_reqser.py
@@ -2,7 +2,7 @@ import unittest
 
 from scrapy.http import Request, FormRequest
 from scrapy.spiders import Spider
-from scrapy.utils.reqser import request_to_dict, request_from_dict
+from scrapy.utils.reqser import request_to_dict, request_from_dict, _get_method
 
 
 class RequestSerializationTest(unittest.TestCase):
@@ -131,6 +131,10 @@ class RequestSerializationTest(unittest.TestCase):
         r = Request("http://www.example.com", callback=spider.parse)
         setattr(spider, 'parse', None)
         self.assertRaises(ValueError, request_to_dict, r, spider=spider)
+
+    def test_func_name(self):
+        # GROUP 12 ADDED TEST CASE
+        self.assertRaises(ValueError, _get_method, self.spider, "")
 
 
 class TestSpiderMixin:


### PR DESCRIPTION
Add test for when the parameter name is not found in the parameter input obj, this induces
statement coverage of 100% for the function `_get_method` in the file
`reqser.py`. This function's tests lie within the file `test_utils_reqser.py`.

issue #9, #15